### PR TITLE
Clone Signal-Desktop to correct folder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If this throws an error, check the debug log for [this problem](https://github.c
 ```bash
 cd node_modules
 rm -rf signal-desktop
-git clone "https://github.com/signalapp/Signal-Desktop.git" signal-desktop
+git clone "https://github.com/signalapp/signal-desktop.git"
 cd signal-desktop
 git checkout v0.39.0
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If this throws an error, check the debug log for [this problem](https://github.c
 ```bash
 cd node_modules
 rm -rf signal-desktop
-git clone "https://github.com/signalapp/Signal-Desktop.git"
+git clone "https://github.com/signalapp/Signal-Desktop.git" signal-desktop
 cd signal-desktop
 git checkout v0.39.0
 ```


### PR DESCRIPTION
Error is thrown with unable to find file path unless name is lowercase.