### PR TITLE
fix puppeting by adding aliases

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,7 @@ new Cli({
       reg.setAppServiceToken(AppServiceRegistration.generateToken());
       reg.setSenderLocalpart("signalbot");
       reg.addRegexPattern("users", "@signal_.*", true);
+      reg.addRegexPattern("aliases", "#signal_.*", true);
       callback(reg);
     }).catch(err=>{
       console.error(err.message);


### PR DESCRIPTION
This has become a mandatory parameter for puppet bridges. Otherwise messages will be rejected by matrix / matrix-puppet.