### PR TITLE
Fix package-installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1116,8 +1116,8 @@
       }
     },
     "matrix-puppet-bridge": {
-      "version": "github:matrix-hacks/matrix-puppet-bridge#decce787d84a7db575924dd1286d01779d6aecf6",
-      "from": "github:matrix-hacks/matrix-puppet-bridge#decce78",
+      "version": "github:matrix-hacks/matrix-puppet-bridge#186331f118c7c65e5617bdfa99f17e665935c3ef",
+      "from": "github:matrix-hacks/matrix-puppet-bridge#186331f",
       "requires": {
         "bluebird": "^3.4.6",
         "concat-stream": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   },
   "dependencies": {
     "matrix-puppet-bridge": "github:matrix-hacks/matrix-puppet-bridge#186331f",
-    "signal-client": "nr23730/node-signal-client#307c5b0"
+    "signal-client": "matrix-hacks/node-signal-client#307c5b0"
   }
 }


### PR DESCRIPTION
Currently matrix-puppet-signal can't be installed, or installs incorrectly due to wrong package-references in package.json and package-lock.json.

This PR fixes 2 such errors.